### PR TITLE
Enable LGTM on univocity parsers repository

### DIFF
--- a/quarkus-univocity-parsers.tf
+++ b/quarkus-univocity-parsers.tf
@@ -38,3 +38,11 @@ resource "github_team_membership" "quarkus_univocity_parsers" {
   username = each.value
   role     = "maintainer"
 }
+
+# Enable apps in repository
+resource "github_app_installation_repository" "quarkus_univocity_parsers" {
+  for_each = { for app in [local.applications.lgtm] : app => app }
+  # The installation id of the app (in the organization).
+  installation_id = each.value
+  repository      = github_repository.quarkus_univocity_parsers.name
+}


### PR DESCRIPTION
After reading the @gastaldi email about the LGTM's plugin, obviously it should be enabled on univocity-parsers-repository