### PR TITLE
Rename quarkus-apache-pinot to quarkus-pinot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
 main.tf                                     @quarkiverse/quarkiverse-owners
 quarkus-amazon-alexa.tf                     @quarkiverse/quarkiverse-amazon-alexa
 quarkus-amazon-services.tf                  @quarkiverse/quarkiverse-amazon-services
-quarkus-apache-pinot.tf                     @quarkiverse/quarkiverse-apache-pinot
 quarkus-artemis.tf                          @quarkiverse/quarkiverse-artemis
 quarkus-arthas.tf                           @quarkiverse/quarkiverse-arthas
 quarkus-config-extensions.tf                @quarkiverse/quarkiverse-config-extensions
@@ -52,6 +51,7 @@ quarkus-ngrok.tf                            @quarkiverse/quarkiverse-ngrok
 quarkus-openapi-generator.tf                @quarkiverse/quarkiverse-openapi-generator
 quarkus-opencv.tf                           @quarkiverse/quarkiverse-opencv
 quarkus-operator-sdk.tf                     @quarkiverse/quarkiverse-operator-sdk
+quarkus-pinot.tf                            @quarkiverse/quarkiverse-pinot
 quarkus-prettytime.tf                       @quarkiverse/quarkiverse-prettytime
 quarkus-pusher-beams.tf                     @quarkiverse/quarkiverse-pusher-beams
 quarkus-qson.tf                             @quarkiverse/quarkiverse-qson

--- a/quarkus-pinot.tf
+++ b/quarkus-pinot.tf
@@ -1,6 +1,6 @@
 # Create repository
 resource "github_repository" "quarkus_apache_pinot" {
-  name                   = "quarkus-apache-pinot"
+  name                   = "quarkus-pinot"
   description            = "Quarkus Apache Pinot extension"
   archive_on_destroy     = true
   delete_branch_on_merge = true
@@ -17,7 +17,7 @@ resource "github_repository" "quarkus_apache_pinot" {
 
 # Create team
 resource "github_team" "quarkus_apache_pinot" {
-  name                      = "quarkiverse-apache-pinot"
+  name                      = "quarkiverse-pinot"
   description               = "Quarkiverse team for the Apache Pinot extension"
   create_default_maintainer = false
   privacy                   = "closed"


### PR DESCRIPTION
Renames the https://github.com/quarkiverse/quarkus-apache-pinot/ repo to https://github.com/quarkiverse/quarkus-pinot