### PR TITLE
Set up repository and team for Quarkus Reactive MySQL Pool Client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,7 @@ quarkus-pusher-beams.tf                     @quarkiverse/quarkiverse-pusher-beam
 quarkus-quinoa.tf                           @quarkiverse/quarkiverse-quinoa
 quarkus-rabbitmq-client.tf                  @quarkiverse/quarkiverse-rabbitmq-client
 quarkus-reactive-h2-client                  @quarkiverse/quarkiverse-reactive-h2-client
+quarkus-reactive-mysql-pool-client          @quarkiverse/quarkiverse-reactive-mysql-pool-client
 quarkus-reactive-messaging-http.tf          @quarkiverse/quarkiverse-reactive-messaging-http
 quarkus-renarde.tf                          @quarkiverse/quarkiverse-renarde
 quarkus-rsocket.tf                          @quarkiverse/quarkiverse-rsocket

--- a/quarkus-reactive-mysql-pool-client.tf
+++ b/quarkus-reactive-mysql-pool-client.tf
@@ -1,0 +1,35 @@
+# Create repository
+resource "github_repository" "quarkus_reactive_mysql_pool_client" {
+  name                   = "quarkus-reactive-mysql-pool-client"
+  description            = "Reactive MySQL Pool client for Quarkus"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "mysql", "reactive"]
+}
+
+# Create team
+resource "github_team" "quarkus_reactive_mysql_pool_client" {
+  name                      = "quarkiverse-reactive-mysql-pool-client"
+  description               = "reactive-mysql-pool-client team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_reactive_mysql_pool_client" {
+  team_id    = github_team.quarkus_reactive_mysql_pool_client.id
+  repository = github_repository.quarkus_reactive_mysql_pool_client.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_reactive_mysql_pool_client" {
+  for_each = { for tm in ["benstonezhang"] : tm => tm }
+  team_id  = github_team.quarkus_reactive_mysql_pool_client.id
+  username = each.value
+  role     = "maintainer"
+}


### PR DESCRIPTION
- Set up repository and team for the Quarkus Reactive MySQL Pool Client
- Add users to the team and set role to maintainer
- Add `quarkus-reactive-mysql-pool-client` to the `CODEOWNERS` file
- Fixes https://github.com/quarkusio/quarkus/issues/31492
