### PR TITLE
Hibernate-Search-Extras: Allow maintainers and actions-users to push to main (for releases)

### DIFF
--- a/quarkus-hibernate-search-extras.tf
+++ b/quarkus-hibernate-search-extras.tf
@@ -50,6 +50,11 @@ resource "github_branch_protection" "quarkus_hibernate_search_extras_main" {
   allows_deletions                = false
   require_conversation_resolution = true
 
+  push_restrictions = [
+    github_team.quarkus_hibernate_search_extras.node_id,
+    "/actions-user"
+  ]
+
   required_status_checks {
     strict   = false
     contexts = ["build"]


### PR DESCRIPTION
Without this the release process does not work on protected branches (see #151).