### PR TITLE
Allow auto-merge on quarkus-hibernate-search-extras

### DIFF
--- a/quarkus-hibernate-search-extras.tf
+++ b/quarkus-hibernate-search-extras.tf
@@ -7,6 +7,7 @@ resource "github_repository" "quarkus_hibernate_search_extras" {
   has_issues             = true
   vulnerability_alerts   = true
   topics                 = ["quarkus-extension"]
+  allow_auto_merge       = true
 }
 
 # Create team


### PR DESCRIPTION
I have access to the setting on the UI, but it looks like Terraform will reset it every time it runs :roll_eyes: