### PR TITLE
Remove branch protection for quarkus-hibernate-search-extras

### DIFF
--- a/quarkus-hibernate-search-extras.tf
+++ b/quarkus-hibernate-search-extras.tf
@@ -7,7 +7,6 @@ resource "github_repository" "quarkus_hibernate_search_extras" {
   has_issues             = true
   vulnerability_alerts   = true
   topics                 = ["quarkus-extension"]
-  allow_auto_merge       = true
 }
 
 # Create team
@@ -40,24 +39,4 @@ resource "github_app_installation_repository" "quarkus_hibernate_search_extras" 
   # The installation id of the app (in the organization).
   installation_id = each.value
   repository      = github_repository.quarkus_hibernate_search_extras.name
-}
-
-# Enable branch protection so that we can use auto-merge (see https://github.com/quarkiverse/quarkiverse/issues/106)
-resource "github_branch_protection" "quarkus_hibernate_search_extras_main" {
-  repository_id = github_repository.quarkus_hibernate_search_extras.node_id
-
-  pattern                         = "main"
-  enforce_admins                  = false
-  allows_deletions                = false
-  require_conversation_resolution = true
-
-  push_restrictions = [
-    github_team.quarkus_hibernate_search_extras.node_id,
-    "/actions-user"
-  ]
-
-  required_status_checks {
-    strict   = false
-    contexts = ["build"]
-  }
 }


### PR DESCRIPTION
To enable auto-merge, we need to require status checks to pass before anyone can push to the branch. Which I did.

Problem is, this affects not only pull requests, but also direct pushes, which become impossible: one now has to push to a new branch, wait for status checks to pass, and only then can it get merged into `main`.

Since the Quarkiverse release process does not do that, it's fundamentally incompatible with requiring status checks to pass, and thus with auto-merge.

So, I'm giving up and reverting the configuration of `quarkus-hibernate-search-extras` to what it was before this whole experiment.

Sorry about the noise.