### PR TITLE
Configure GitHub repo for Quarkus MCP Server with Terraform

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,7 @@ terraform-scripts/quarkus-logging-splunk.tf                     @quarkiverse/qua
 terraform-scripts/quarkus-lucene.tf                             @quarkiverse/quarkiverse-lucene
 terraform-scripts/quarkus-mailpit.tf                            @quarkiverse/quarkiverse-mailpit
 terraform-scripts/quarkus-maven-resolver.tf                     @quarkiverse/quarkiverse-maven-resolver
+terraform-scripts/quarkus-mcp-server.tf                         @quarkiverse/quarkiverse-mcp-server
 terraform-scripts/quarkus-mdns.tf                               @quarkiverse/quarkiverse-mdns
 terraform-scripts/quarkus-mfa.tf                                @quarkiverse/quarkiverse-mfa
 terraform-scripts/quarkus-micrometer-registry.tf                @quarkiverse/quarkiverse-micrometer-registry

--- a/terraform-scripts/quarkus-mcp-server.tf
+++ b/terraform-scripts/quarkus-mcp-server.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_mcp_server" {
+  name                   = "quarkus-mcp-server"
+  description            = "This extension enables developers to implement the MCP server features easily."
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-mcp-server/dev/"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension"]
+}
+
+# Create team
+resource "github_team" "quarkus_mcp_server" {
+  name                      = "quarkiverse-mcp-server"
+  description               = "mcp-server team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_mcp_server" {
+  team_id    = github_team.quarkus_mcp_server.id
+  repository = github_repository.quarkus_mcp_server.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_mcp_server" {
+  for_each = { for tm in ["mkouba"] : tm => tm }
+  team_id  = github_team.quarkus_mcp_server.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_mcp_server" {
+  name        = "main"
+  repository  = github_repository.quarkus_mcp_server.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
- Add Terraform script for GitHub repository management of Quarkus MCP Server, including repository setup, branch protections, and team permissions.
- Implement CODEOWNERS file update to include new Terraform script, ensuring appropriate code review coverage.
- Fixes https://github.com/quarkusio/quarkus/issues/45054
