### PR TITLE
Introduce `quarkus-sqlite4j`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -135,6 +135,7 @@ terraform-scripts/quarkus-shardingsphere-jdbc.tf                @quarkiverse/qua
 terraform-scripts/quarkus-shedlock.tf                           @quarkiverse/quarkiverse-shedlock
 terraform-scripts/quarkus-smallrye-opentracing.tf               @quarkiverse/quarkiverse-smallrye-opentracing
 terraform-scripts/quarkus-snappy.tf                             @quarkiverse/quarkiverse-snappy
+terraform-scripts/quarkus-sqlite4j.tf                           @quarkiverse/quarkiverse-sqlite4j
 terraform-scripts/quarkus-sshd.tf                               @quarkiverse/quarkiverse-sshd
 terraform-scripts/quarkus-systemd-notify.tf                     @quarkiverse/quarkiverse-systemd-notify
 terraform-scripts/quarkus-tekton-client.tf                      @quarkiverse/quarkiverse-tekton-client

--- a/terraform-scripts/quarkus-sqlite4j.tf
+++ b/terraform-scripts/quarkus-sqlite4j.tf
@@ -1,0 +1,36 @@
+# Create repository
+resource "github_repository" "quarkus_sqlite4j" {
+  name                   = "quarkus-sqlite4j"
+  description            = "SQLite driver for Quarkus with Agroal in pure Java built on SQLite4j"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-sqlite4j/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension"]
+}
+
+# Create team
+resource "github_team" "quarkus_sqlite4j" {
+  name                      = "quarkiverse-sqlite4j"
+  description               = "sqlite4j team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_sqlite4j" {
+  team_id    = github_team.quarkus_sqlite4j.id
+  repository = github_repository.quarkus_sqlite4j.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_sqlite4j" {
+  for_each = { for tm in ["andreaTP"] : tm => tm }
+  team_id  = github_team.quarkus_sqlite4j.id
+  username = each.value
+  role     = "maintainer"
+}


### PR DESCRIPTION
- Introduce Terraform script to automate creation and access configuration for the Quarkus SQLite4j GitHub repository.
- Configure code ownership for the Quarkus SQLite4j Terraform module to ensure maintainability and review standards.
- Fixes https://github.com/quarkusio/quarkus/issues/46063