### PR TITLE
Rename `quarkus-sqlite4j` to `quarkus-jdbc-sqlite4j`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,6 +54,7 @@ terraform-scripts/quarkus-jberet.tf                             @quarkiverse/qua
 terraform-scripts/quarkus-jdbc-clickhouse.tf                    @quarkiverse/quarkiverse-jdbc-clickhouse
 terraform-scripts/quarkus-jdbc-singlestore.tf                   @quarkiverse/quarkiverse-jdbc-singlestore
 terraform-scripts/quarkus-jdbc-sqlite.tf                        @quarkiverse/quarkiverse-jdbc-sqlite
+terraform-scripts/quarkus-jdbc-sqlite4j.tf                      @quarkiverse/quarkiverse-jdbc-sqlite4j
 terraform-scripts/quarkus-jdbi.tf                               @quarkiverse/quarkiverse-jdbi
 terraform-scripts/quarkus-jdiameter.tf                          @quarkiverse/quarkiverse-jdiameter
 terraform-scripts/quarkus-jef.tf                                @quarkiverse/quarkiverse-jef
@@ -135,7 +136,6 @@ terraform-scripts/quarkus-shardingsphere-jdbc.tf                @quarkiverse/qua
 terraform-scripts/quarkus-shedlock.tf                           @quarkiverse/quarkiverse-shedlock
 terraform-scripts/quarkus-smallrye-opentracing.tf               @quarkiverse/quarkiverse-smallrye-opentracing
 terraform-scripts/quarkus-snappy.tf                             @quarkiverse/quarkiverse-snappy
-terraform-scripts/quarkus-sqlite4j.tf                           @quarkiverse/quarkiverse-sqlite4j
 terraform-scripts/quarkus-sshd.tf                               @quarkiverse/quarkiverse-sshd
 terraform-scripts/quarkus-systemd-notify.tf                     @quarkiverse/quarkiverse-systemd-notify
 terraform-scripts/quarkus-tekton-client.tf                      @quarkiverse/quarkiverse-tekton-client

--- a/terraform-scripts/quarkus-jdbc-sqlite4j.tf
+++ b/terraform-scripts/quarkus-jdbc-sqlite4j.tf
@@ -1,6 +1,6 @@
 # Create repository
 resource "github_repository" "quarkus_sqlite4j" {
-  name                   = "quarkus-sqlite4j"
+  name                   = "quarkus-jdbc-sqlite4j"
   description            = "SQLite driver for Quarkus with Agroal in pure Java built on SQLite4j"
   homepage_url           = "https://docs.quarkiverse.io/quarkus-sqlite4j/dev"
   allow_update_branch    = true
@@ -8,12 +8,12 @@ resource "github_repository" "quarkus_sqlite4j" {
   delete_branch_on_merge = true
   has_issues             = true
   vulnerability_alerts   = true
-  topics                 = ["quarkus-extension"]
+  topics                 = ["jdbc", "sqlite", "quarkus-extension"]
 }
 
 # Create team
 resource "github_team" "quarkus_sqlite4j" {
-  name                      = "quarkiverse-sqlite4j"
+  name                      = "quarkiverse-jdbc-sqlite4j"
   description               = "sqlite4j team"
   create_default_maintainer = false
   privacy                   = "closed"


### PR DESCRIPTION
- Rename and refactor Terraform script to align with `quarkus-jdbc-sqlite4j` naming convention.
