### PR TITLE
Enable sync2jira for quarkus-hibernate-search-extras and quarkus-lucene

### DIFF
--- a/terraform-scripts/main.tf
+++ b/terraform-scripts/main.tf
@@ -41,5 +41,17 @@ locals {
     lgtm = "24341616"
     # Renovate - https://github.com/marketplace/renovate
     renovate = "34650047"
+    # This enables a webhook to send events from these repositories
+    # to Fedora Messaging,
+    # which is used by a separately configured Sync2Jira instance
+    # to replicate GitHub issues to issues.redhat.com.
+    # The point is to allow Red Hat engineers to use this internally
+    # to prioritize their work.
+    # Only public information is shared.
+    # See:
+    # https://github.com/release-engineering/Sync2Jira/
+    # https://github.com/fedora-infra/webhook-to-fedora-messaging/
+    # https://issues.redhat.com/projects/GHQKIVERSE
+    sync2jira_redhat = "1137195"
   }
 }

--- a/terraform-scripts/quarkus-hibernate-search-extras.tf
+++ b/terraform-scripts/quarkus-hibernate-search-extras.tf
@@ -43,7 +43,7 @@ resource "github_repository_collaborator" "quarkus_hibernate_search_extras" {
 
 # Enable apps in repository
 resource "github_app_installation_repository" "quarkus_hibernate_search_extras" {
-  for_each = { for app in [local.applications.lgtm] : app => app }
+  for_each = { for app in [local.applications.lgtm, local.applications.sync2jira_redhat] : app => app }
   # The installation id of the app (in the organization).
   installation_id = each.value
   repository      = github_repository.quarkus_hibernate_search_extras.name

--- a/terraform-scripts/quarkus-lucene.tf
+++ b/terraform-scripts/quarkus-lucene.tf
@@ -38,3 +38,11 @@ resource "github_team_membership" "quarkus_lucene" {
   username = each.value
   role     = "maintainer"
 }
+
+# Enable apps in repository
+resource "github_app_installation_repository" "quarkus_lucene" {
+  for_each = { for app in [local.applications.sync2jira_redhat] : app => app }
+  # The installation id of the app (in the organization).
+  installation_id = each.value
+  repository      = github_repository.quarkus_lucene.name
+}


### PR DESCRIPTION
This enables a webhook to send events from these repositories to Fedora Messaging,
which is used by a separately configured Sync2Jira instance to replicate GitHub issues to issues.redhat.com.

The point is to allow Red Hat engineers to use this internally to prioritize their work.

Only public information is shared.

The GitHub app was already created and installed in the Quarkiverse org by @gsmet .

@dainiusjocas I took the liberty of enabling this for quarkus-lucene, I hope it's alright? It's just about replicating public GitHub issues to an internal tool. It's not like my team has been contributing much so far, but we'd like to one day, in particular to address https://github.com/quarkiverse/quarkus-hibernate-search-extras/issues/179 / https://github.com/quarkiverse/quarkus-hibernate-search-extras/issues/180

cc @marko-bekhta 

See:

https://github.com/release-engineering/Sync2Jira/
https://github.com/fedora-infra/webhook-to-fedora-messaging/
https://issues.redhat.com/projects/GHQKIVERSE (may not be accessible publicly, sorry, but it's basically just copies of GitHub issues)