### PR TITLE
Add GitHub repo and team setup for quarkus-tekton

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -138,6 +138,7 @@ terraform-scripts/quarkus-smallrye-opentracing.tf               @quarkiverse/qua
 terraform-scripts/quarkus-snappy.tf                             @quarkiverse/quarkiverse-snappy
 terraform-scripts/quarkus-sshd.tf                               @quarkiverse/quarkiverse-sshd
 terraform-scripts/quarkus-systemd-notify.tf                     @quarkiverse/quarkiverse-systemd-notify
+terraform-scripts/quarkus-tekton.tf                             @quarkiverse/quarkiverse-tekton
 terraform-scripts/quarkus-tekton-client.tf                      @quarkiverse/quarkiverse-tekton-client
 terraform-scripts/quarkus-temporal.tf                           @quarkiverse/quarkiverse-temporal
 terraform-scripts/quarkus-tika.tf                               @quarkiverse/quarkiverse-tika

--- a/terraform-scripts/quarkus-tekton.tf
+++ b/terraform-scripts/quarkus-tekton.tf
@@ -1,0 +1,36 @@
+# Create repository
+resource "github_repository" "quarkus_tekton" {
+  name                   = "quarkus-tekton"
+  description            = "A Tekton extension for Quarkus"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-tekton/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "tekton"]
+}
+
+# Create team
+resource "github_team" "quarkus_tekton" {
+  name                      = "quarkiverse-tekton"
+  description               = "Quarkiverse team for the tekton extension"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_tekton" {
+  team_id    = github_team.quarkus_tekton.id
+  repository = github_repository.quarkus_tekton.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_tekton" {
+  for_each = { for tm in ["iocanel", "aureamunoz", "cmoulliard"] : tm => tm }
+  team_id  = github_team.quarkus_tekton.id
+  username = each.value
+  role     = "maintainer"
+}


### PR DESCRIPTION
- Configure `quarkus-tekton` GitHub repository with tailored settings, team permissions, and maintainers via Terraform.
- Add a CODEOWNERS entry to ensure proper ownership and maintain accountability for the Terraform script.
- Fixes https://github.com/quarkusio/quarkus/issues/46400
