### PR TITLE
Add GitHub repo setup for quarkus-openapi-problem

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,6 +104,7 @@ terraform-scripts/quarkus-oidc-proxy.tf                         @quarkiverse/qua
 terraform-scripts/quarkus-omnifaces.tf                          @quarkiverse/quarkiverse-omnifaces
 terraform-scripts/quarkus-open-feature.tf                       @quarkiverse/quarkiverse-open-feature
 terraform-scripts/quarkus-openapi-generator.tf                  @quarkiverse/quarkiverse-openapi-generator
+terraform-scripts/quarkus-openapi-problems.tf                   @quarkiverse/quarkiverse-openapi-problems
 terraform-scripts/quarkus-opencv.tf                             @quarkiverse/quarkiverse-opencv
 terraform-scripts/quarkus-openfga-client.tf                     @quarkiverse/quarkiverse-openfga-client
 terraform-scripts/quarkus-opensearch.tf                         @quarkiverse/quarkiverse-opensearch

--- a/terraform-scripts/quarkus-openapi-problem.tf
+++ b/terraform-scripts/quarkus-openapi-problem.tf
@@ -1,0 +1,41 @@
+# Create repository
+resource "github_repository" "quarkus_openapi_problem" {
+  name                   = "quarkus-openapi-problem"
+  description            = "Standardized error responses for Quarkus REST APIs using Problem Details (RFC9457)"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-openapi-problem/dev"
+  allow_update_branch    = true
+  allow_merge_commit     = true
+  allow_rebase_merge     = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  has_discussions        = true
+  has_downloads          = true
+  has_wiki               = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "rfc9457", "openapi", "rest", "resteasy", "jaxrs", "json", "jackson", "jakarta-rest", "problem", "error", "exception"]
+}
+
+# Create team
+resource "github_team" "quarkus_openapi_problem" {
+  name                      = "quarkiverse-openapi-problem"
+  description               = "openapi-problem team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_openapi_problem" {
+  team_id    = github_team.quarkus_openapi_problem.id
+  repository = github_repository.quarkus_openapi_problem.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_openapi_problem" {
+  for_each = { for tm in ["melloware", "tmulle", "lwitkowski"] : tm => tm }
+  team_id  = github_team.quarkus_openapi_problem.id
+  username = each.value
+  role     = "maintainer"
+}


### PR DESCRIPTION
- Add CODEOWNERS entry for `quarkiverse/quarkiverse-openapi-problems` to streamline repository ownership and responsibility.
- Implement Terraform script to automate the creation and configuration of the `quarkus-openapi-problem` GitHub repository, including team permissions and maintainer assignments.
- Fixes https://github.com/quarkusio/quarkus/issues/46878