### PR TITLE
Add Terraform script for Quarkus Docker client repo setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ terraform-scripts/quarkus-cxf.tf                                @quarkiverse/qua
 terraform-scripts/quarkus-dapr.tf                               @quarkiverse/quarkiverse-dapr
 terraform-scripts/quarkus-dashbuilder.tf                        @quarkiverse/quarkiverse-dashbuilder
 terraform-scripts/quarkus-discord4j.tf                          @quarkiverse/quarkiverse-discord4j
+terraform-scripts/quarkus-docker-client.tf                      @quarkiverse/quarkiverse-docker-client
 terraform-scripts/quarkus-doma.tf                               @quarkiverse/quarkiverse-doma
 terraform-scripts/quarkus-easy-retrofit.tf                      @quarkiverse/quarkiverse-easy-retrofit
 terraform-scripts/quarkus-eddi.tf                               @quarkiverse/quarkiverse-eddi

--- a/terraform-scripts/quarkus-docker-client.tf
+++ b/terraform-scripts/quarkus-docker-client.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_docker_client" {
+  name                   = "quarkus-docker-client"
+  description            = "Docker Java client integration for Quarkus"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-docker-client/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "docker", "docker-api", "container", "containerization"]
+}
+
+# Create team
+resource "github_team" "quarkus_docker_client" {
+  name                      = "quarkiverse-docker-client"
+  description               = "docker-client team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_docker_client" {
+  team_id    = github_team.quarkus_docker_client.id
+  repository = github_repository.quarkus_docker_client.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_docker_client" {
+  for_each = { for tm in ["zZHorizonZz"] : tm => tm }
+  team_id  = github_team.quarkus_docker_client.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_docker_client" {
+  name        = "main"
+  repository  = github_repository.quarkus_docker_client.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
- Set up infrastructure for managing the Quarkus Docker client repository in GitHub via Terraform.
- Define repository ownership and permissions, including team roles, branch protection rules, and app overrides.
- Establish CODEOWNERS file for streamlined code review and ownership delegation.
- Fixes https://github.com/quarkusio/quarkus/issues/44255