### PR TITLE
Introduce `quarkus-docling`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@ terraform-scripts/quarkus-dapr.tf                               @quarkiverse/qua
 terraform-scripts/quarkus-dashbuilder.tf                        @quarkiverse/quarkiverse-dashbuilder
 terraform-scripts/quarkus-discord4j.tf                          @quarkiverse/quarkiverse-discord4j
 terraform-scripts/quarkus-docker-client.tf                      @quarkiverse/quarkiverse-docker-client
+terraform-scripts/quarkus-docling.tf                            @quarkiverse/quarkiverse-docling
 terraform-scripts/quarkus-doma.tf                               @quarkiverse/quarkiverse-doma
 terraform-scripts/quarkus-easy-retrofit.tf                      @quarkiverse/quarkiverse-easy-retrofit
 terraform-scripts/quarkus-eddi.tf                               @quarkiverse/quarkiverse-eddi

--- a/terraform-scripts/quarkus-docling.tf
+++ b/terraform-scripts/quarkus-docling.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_docling" {
+  name                   = "quarkus-docling"
+  description            = "Docling simplifies document processing, parsing diverse formats — including advanced PDF understanding — and providing seamless integrations with the gen AI ecosystem"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-docling/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "quarkus", "docling", "ai", "document-processing", "rag", "embedding"]
+}
+
+# Create team
+resource "github_team" "quarkus_docling" {
+  name                      = "quarkiverse-docling"
+  description               = "docling team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_docling" {
+  team_id    = github_team.quarkus_docling.id
+  repository = github_repository.quarkus_docling.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_docling" {
+  for_each = { for tm in ["edeandrea", "lordofthejars"] : tm => tm }
+  team_id  = github_team.quarkus_docling.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_docling" {
+  name        = "main"
+  repository  = github_repository.quarkus_docling.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
```
- Add Terraform configuration to automate the creation and management of the `quarkus-docling` GitHub repository, team, and permissions.
- Implement branch protection rules and assign code ownership for improved repository governance.
```
