### PR TITLE
Introduce `quarkus-rage4j` repository and team setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -128,6 +128,7 @@ terraform-scripts/quarkus-quickjs4j.tf                          @quarkiverse/qua
 terraform-scripts/quarkus-quinoa.tf                             @quarkiverse/quarkiverse-quinoa
 terraform-scripts/quarkus-qute-web.tf                           @quarkiverse/quarkiverse-qute-web
 terraform-scripts/quarkus-rabbitmq-client.tf                    @quarkiverse/quarkiverse-rabbitmq-client
+terraform-scripts/quarkus-rage4j.tf                             @quarkiverse/quarkiverse-rage4j
 terraform-scripts/quarkus-reactive-h2-client                    @quarkiverse/quarkiverse-reactive-h2-client
 terraform-scripts/quarkus-reactive-mysql-pool-client            @quarkiverse/quarkiverse-reactive-mysql-pool-client
 terraform-scripts/quarkus-reactive-messaging-http.tf            @quarkiverse/quarkiverse-reactive-messaging-http

--- a/terraform-scripts/quarkus-rage4j.tf
+++ b/terraform-scripts/quarkus-rage4j.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_rage4j" {
+  name                   = "quarkus-rage4j"
+  description            = "Rage4j is a java library thats helps evaluate LLM's based on scientifically grounded metrics"
+  homepage_url           = "https://explore-de.github.io/rage4j/"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "large-language-models", "llms", "continuous-integration", "ai", "llm-testing", "semantic-evaluation", "testing-library", "langchain4j", "openai"]
+}
+
+# Create team
+resource "github_team" "quarkus_rage4j" {
+  name                      = "quarkiverse-rage4j"
+  description               = "rage4j team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_rage4j" {
+  team_id    = github_team.quarkus_rage4j.id
+  repository = github_repository.quarkus_rage4j.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_rage4j" {
+  for_each = { for tm in ["d135-1r43", "vladislavkn", "vvilip"] : tm => tm }
+  team_id  = github_team.quarkus_rage4j.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_rage4j" {
+  name        = "main"
+  repository  = github_repository.quarkus_rage4j.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
- Add `quarkus-rage4j` repository infrastructure with Terraform, including settings, permissions, and branch protection rules.
- Assign ownership of `quarkus-rage4j` to `@quarkiverse/quarkiverse-rage4j` in CODEOWNERS.
- Fixes https://github.com/quarkusio/quarkus/issues/48236