### PR TITLE
Introduce `quarkus-datafaker`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,6 +28,7 @@ terraform-scripts/quarkus-cucumber.tf                           @quarkiverse/qua
 terraform-scripts/quarkus-cxf.tf                                @quarkiverse/quarkiverse-cxf
 terraform-scripts/quarkus-dapr.tf                               @quarkiverse/quarkiverse-dapr
 terraform-scripts/quarkus-dashbuilder.tf                        @quarkiverse/quarkiverse-dashbuilder
+terraform-scripts/quarkus-datafaker.tf                          @quarkiverse/quarkiverse-datafaker
 terraform-scripts/quarkus-discord4j.tf                          @quarkiverse/quarkiverse-discord4j
 terraform-scripts/quarkus-docker-client.tf                      @quarkiverse/quarkiverse-docker-client
 terraform-scripts/quarkus-docling.tf                            @quarkiverse/quarkiverse-docling

--- a/terraform-scripts/quarkus-datafaker.tf
+++ b/terraform-scripts/quarkus-datafaker.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_datafaker" {
+  name                   = "quarkus-datafaker"
+  description            = "Support Datafaker for native compilation"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-datafaker/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "datafaker"]
+}
+
+# Create team
+resource "github_team" "quarkus_datafaker" {
+  name                      = "quarkiverse-datafaker"
+  description               = "datafaker team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_datafaker" {
+  team_id    = github_team.quarkus_datafaker.id
+  repository = github_repository.quarkus_datafaker.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_datafaker" {
+  for_each = { for tm in ["jponge", "radcortez"] : tm => tm }
+  team_id  = github_team.quarkus_datafaker.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_datafaker" {
+  name        = "main"
+  repository  = github_repository.quarkus_datafaker.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
- Add Terraform script to automate creation and configuration of the `quarkus-datafaker` GitHub repository and associated team.
- Configure repository settings, branch protections, and team permissions to align with project governance standards.
- Establish code ownership for the new Terraform script.
- Fixes https://github.com/quarkusio/quarkus/issues/50525
