### PR TITLE
[quarkus-docling] - Add Java version 25 to default JVM testing list

### DIFF
--- a/terraform-scripts/quarkus-docling.tf
+++ b/terraform-scripts/quarkus-docling.tf
@@ -46,7 +46,8 @@ variable "os_jvm_combos" {
   }))
   default = [
     { os = "ubuntu-latest", java_version = 17 },
-    { os = "ubuntu-latest", java_version = 21 }
+    { os = "ubuntu-latest", java_version = 21 },
+    { os = "ubuntu-latest", java_version = 25 }
   ]
 }
 


### PR DESCRIPTION
Want to add a rule to force an additional version test against Java 25