### PR TITLE
Set up repository and permissions for quarkus-mapstruct

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -90,6 +90,7 @@ terraform-scripts/quarkus-logging-sentry.tf                     @quarkiverse/qua
 terraform-scripts/quarkus-logging-splunk.tf                     @quarkiverse/quarkiverse-logging-splunk
 terraform-scripts/quarkus-lucene.tf                             @quarkiverse/quarkiverse-lucene
 terraform-scripts/quarkus-mailpit.tf                            @quarkiverse/quarkiverse-mailpit
+terraform-scripts/quarkus-mapstruct.tf                          @quarkiverse/quarkiverse-mapstruct
 terraform-scripts/quarkus-maven-resolver.tf                     @quarkiverse/quarkiverse-maven-resolver
 terraform-scripts/quarkus-mcp-server.tf                         @quarkiverse/quarkiverse-mcp-server
 terraform-scripts/quarkus-mcp-servers.tf                        @quarkiverse/quarkiverse-mcp-servers

--- a/terraform-scripts/quarkus-mapstruct.tf
+++ b/terraform-scripts/quarkus-mapstruct.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_mapstruct" {
+  name                   = "quarkus-mapstruct"
+  description            = "MapStruct is a code generator that greatly simplifies the implementation of mappings between Java bean types based on a convention over configuration approach."
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-mapstruct/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension", "mapstruct"]
+}
+
+# Create team
+resource "github_team" "quarkus_mapstruct" {
+  name                      = "quarkiverse-mapstruct"
+  description               = "mapstruct team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_mapstruct" {
+  team_id    = github_team.quarkus_mapstruct.id
+  repository = github_repository.quarkus_mapstruct.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_mapstruct" {
+  for_each = { for tm in ["Postremus"] : tm => tm }
+  team_id  = github_team.quarkus_mapstruct.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_mapstruct" {
+  name        = "main"
+  repository  = github_repository.quarkus_mapstruct.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
- Provision infrastructure for the `quarkus-mapstruct` repository, including repository settings, team configuration, and branch protection rules.
- Establish automated code ownership by integrating `@quarkiverse/quarkiverse-mapstruct` into the `.github/CODEOWNERS` file.
- Fixes https://github.com/quarkusio/quarkus/issues/5956
