### PR TITLE
Add @mcruzdev as a maintainer in quarkus-flow

### DIFF
--- a/terraform-scripts/quarkus-flow.tf
+++ b/terraform-scripts/quarkus-flow.tf
@@ -29,7 +29,7 @@ resource "github_team_repository" "quarkus_flow" {
 
 # Add users to the team
 resource "github_team_membership" "quarkus_flow" {
-  for_each = { for tm in ["ricardozanini", "fjtirado"] : tm => tm }
+  for_each = { for tm in ["ricardozanini", "fjtirado", "mcruzdev"] : tm => tm }
   team_id  = github_team.quarkus_flow.id
   username = each.value
   role     = "maintainer"


### PR DESCRIPTION
cc: @ricardozanini 

I am not sure if is intended to be a maintainer, if not I can open a pull request as member:

```tf
# Add users to the team as member
resource "github_team_membership" "quarkus_flow_as_member" {
  for_each = { for tm in ["mcruzdev"] : tm => tm }
  team_id  = github_team.quarkus_flow.id
  username = each.value
  role     = "member"
}
```