### PR TITLE
Following PR-373 as requested by @gastaldi

### DIFF
--- a/terraform-scripts/quarkus-rabbitmq-client.tf
+++ b/terraform-scripts/quarkus-rabbitmq-client.tf
@@ -41,7 +41,7 @@ resource "github_team_membership" "quarkus_rabbitmq_client" {
   role     = "maintainer"
 }
 
-resource "github_repository_ruleset" "quarkus_datafaker" {
+resource "github_repository_ruleset" "quarkus_rabbitmq_client" {
   name        = "main"
   repository  = github_repository.quarkus_rabbitmq_client.name
   target      = "branch"


### PR DESCRIPTION
@gastaldi This incorporates the changes for branch protection rules as requested by you in the PR. I don't know if the section
```
  # Do not use the template below in new repositories. This is kept for backward compatibility with existing repositories
  template {
    owner      = "quarkiverse"
    repository = "quarkiverse-template"
  }

``` 
Can be removed. If so let me know and I'll update the PR.