### PR TITLE
Introduce `quarkus-redoc`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -140,6 +140,7 @@ terraform-scripts/quarkus-reactive-h2-client                    @quarkiverse/qua
 terraform-scripts/quarkus-reactive-mysql-pool-client            @quarkiverse/quarkiverse-reactive-mysql-pool-client
 terraform-scripts/quarkus-reactive-messaging-http.tf            @quarkiverse/quarkiverse-reactive-messaging-http
 terraform-scripts/quarkus-reactive-messaging-nats-jetstream.tf  @quarkiverse/quarkiverse-reactive-messaging-nats-jetstream
+terraform-scripts/quarkus-redoc.tf                              @quarkiverse/quarkiverse-redoc
 terraform-scripts/quarkus-renarde.tf                            @quarkiverse/quarkiverse-renarde
 terraform-scripts/quarkus-resteasy-problem.tf                   @quarkiverse/quarkiverse-resteasy-problem
 terraform-scripts/quarkus-roq.tf                                @quarkiverse/quarkiverse-roq

--- a/terraform-scripts/quarkus-redoc.tf
+++ b/terraform-scripts/quarkus-redoc.tf
@@ -1,0 +1,66 @@
+# Create repository
+resource "github_repository" "quarkus_redoc" {
+  name                   = "quarkus-redoc"
+  description            = "OpenAPI/Swagger-generated API Reference Documentation"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-redoc/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  vulnerability_alerts   = true
+  topics                 = ["quarkus-extension"]
+}
+
+# Create team
+resource "github_team" "quarkus_redoc" {
+  name                      = "quarkiverse-redoc"
+  description               = "redoc team"
+  create_default_maintainer = false
+  privacy                   = "closed"
+  parent_team_id            = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_redoc" {
+  team_id    = github_team.quarkus_redoc.id
+  repository = github_repository.quarkus_redoc.name
+  permission = "maintain"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_redoc" {
+  for_each = { for tm in ["Postremus"] : tm => tm }
+  team_id  = github_team.quarkus_redoc.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_redoc" {
+  name        = "main"
+  repository  = github_repository.quarkus_redoc.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
- Add Terraform configuration for creating and managing the "quarkus-redoc" repository with appropriate team permissions and branch protections.
- Establish code ownership for the repository's Terraform script under the "quarkiverse-redoc" team.
- Implement security and compliance measures like restricted access, pull request reviews, and bypass rules for CI integrations.
- Fixes https://github.com/quarkusio/quarkus/issues/13643
