### PR TITLE
Enable SURGE_TOKEN secret in quarkus-roq

### DIFF
--- a/terraform-scripts/main.tf
+++ b/terraform-scripts/main.tf
@@ -52,4 +52,8 @@ locals {
     # https://issues.redhat.com/projects/GHQKIVERSE
     sync2jira_redhat = "60685343"
   }
+  secrets = {
+    # This secret is used by the GitHub Actions workflow to publish the generated website to Surge.sh
+    surge_token = "SURGE_TOKEN"
+  }
 }

--- a/terraform-scripts/quarkus-roq.tf
+++ b/terraform-scripts/quarkus-roq.tf
@@ -53,3 +53,11 @@ resource "github_repository_collaborator" "quarkus_statiq" {
   username   = each.value
   permission = "admin"
 }
+
+# Add organization secrets
+resource "github_actions_organization_secret_repository" "quarkus_statiq" {
+  for_each      = { for k in [local.secrets.surge_token] : k => k }
+  secret_name   = each.value
+  repository_id = github_repository.quarkus_statiq.repo_id
+}
+


### PR DESCRIPTION
- This will allow the `SURGE_TOKEN` organization secret to be used in workflows in the https://github.com/quarkiverse/quarkus-roq repository