### PR TITLE
Split Terraform workflow to support PRs from forks

### DIFF
--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,125 @@
+name: "Terraform Plan"
+
+on:
+  workflow_run:
+    workflows: ["Terraform"]
+    types:
+      - completed
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  terraform_plan:
+    name: "Terraform Plan"
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'quarkiverse' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: terraform-pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number)" >> $GITHUB_OUTPUT
+
+      - name: Download Terraform scripts
+        uses: actions/download-artifact@v8
+        with:
+          name: terraform-pr-scripts
+          path: terraform-scripts
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "1.14.0"
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+      - name: Terraform Init
+        id: init
+        working-directory: ./terraform-scripts
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        working-directory: ./terraform-scripts
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        working-directory: ./terraform-scripts
+        run: |
+          echo 'PLAN_RESULTS<<EOF' >> $GITHUB_ENV
+          terraform plan -no-color | grep -v "Refreshing state...\|Reading...\|Read complete after" >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
+        continue-on-error: true
+
+      - uses: actions/github-script@v9
+        if: always()
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+            })
+
+            // 2. Prepare format of the comment
+            const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+            <details><summary>Validation Output</summary>
+
+            \`\`\`\n
+            ${{ steps.validate.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+
+            \`\`\`terraform\n
+            ${{ env.PLAN_RESULTS }}
+            \`\`\`
+
+            *Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
+
+            // 3. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
+
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,45 +5,44 @@ on:
     branches:
       - main
 
-permissions: 
-  issues: write
+permissions:
   contents: read
-  pull-requests: write
-  
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  terraform_only_check:
+  terraform_check:
     if: github.repository_owner == 'quarkiverse'
-    name: Check for Terraform Scripts only change
+    name: Check for Terraform Scripts change
     outputs:
-      tf_only: ${{ steps.files.outputs.total_terraform > 0 }}
+      tf_changed: ${{ steps.files.outputs.tf_changed }}
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - id: files
         name: Get changed files
-        run:
-          echo total_terraform=$(gh pr view ${{github.event.pull_request.number}} --json files --jq '.files.[].path'| grep terraform-scripts | wc -l | tr -d ' ') >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tf_count=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- terraform-scripts/ | wc -l | tr -d ' ')
+          echo "tf_changed=$( [ "$tf_count" -gt 0 ] && echo true || echo false )" >> $GITHUB_OUTPUT
 
-  terraform:
-    name: "Terraform"
+  terraform_fmt:
+    name: "Terraform Format"
     runs-on: ubuntu-latest
-    if: (github.repository_owner == 'quarkiverse') && (needs.terraform_only_check.outputs.tf_only == 'true')
+    if: needs.terraform_check.outputs.tf_changed == 'true'
     needs:
-      - terraform_only_check
+      - terraform_check
     defaults:
       run:
         working-directory: ./terraform-scripts
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           sparse-checkout: terraform-scripts
 
@@ -51,81 +50,23 @@ jobs:
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: "1.14.0"
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Terraform Format
-        id: fmt
         run: terraform fmt -check
 
-      - name: Terraform Init
-        id: init
-        run: terraform init
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > "${{ runner.temp }}/pr_number"
 
-      - name: Terraform Validate
-        id: validate
-        run: terraform validate -no-color
-
-      - name: Terraform Plan
-        id: plan
-        if: github.event_name == 'pull_request'
-        run: |
-          echo 'PLAN_RESULTS<<EOF' >> $GITHUB_ENV
-          terraform plan -no-color | grep -v "Refreshing state...\|Reading...\|Read complete after" >> $GITHUB_ENV
-          echo 'EOF' >> $GITHUB_ENV
-        continue-on-error: true
-
-      - uses: actions/github-script@v8
-        if: always() && github.event_name == 'pull_request'
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            // 1. Retrieve existing bot comments for the PR
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            })
-            const botComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
-            })
+          name: terraform-pr-meta
+          path: ${{ runner.temp }}/pr_number
+          retention-days: 1
 
-            // 2. Prepare format of the comment
-            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
-            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-            #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
-            <details><summary>Validation Output</summary>
-
-            \`\`\`\n
-            ${{ steps.validate.outputs.stdout }}
-            \`\`\`
-
-            </details>
-
-            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-
-            \`\`\`terraform\n
-            ${{ env.PLAN_RESULTS }}
-            \`\`\`
-
-            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Workflow: \`${{ github.workflow }}\`*`;
-
-            // 3. If we have a comment, update it, otherwise create a new one
-            if (botComment) {
-              github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: output
-              })
-            } else {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: output
-              })
-            }
-
-      - name: Terraform Plan Status
-        if: steps.plan.outcome == 'failure'
-        run: exit 1
+      - name: Upload Terraform scripts
+        uses: actions/upload-artifact@v7
+        with:
+          name: terraform-pr-scripts
+          path: terraform-scripts/
+          retention-days: 1

--- a/terraform-scripts/README.md
+++ b/terraform-scripts/README.md
@@ -20,7 +20,7 @@ IMPORTANT: Because the VCS is the single source of truth, you can't apply terraf
 
 New repositories are submitted via Pull Requests to the root directory in this repository.
 
-IMPORTANT: The branch must be created in the same repository, it won't work in a separate fork (`@quarkiverse/quarkiverse-members` should be able to create new branches here)
+TIP: Pull Requests from forks are supported. The CI will run format checks on the PR and then run `terraform plan` in a separate workflow with access to the required credentials.
 
 1. Add a new `.tf` script in the `terraform-scripts/` directory with the following structure: 
 


### PR DESCRIPTION
The previous workflow used `gh pr view` (which requires a token) and ran `terraform plan` with secrets, both of which fail for fork PRs.

Split into two workflows:
- `terraform.yml` (pull_request): runs fmt check and uploads artifacts
- `terraform-plan.yml` (workflow_run): runs init/validate/plan with
  secrets and posts the PR comment

This keeps TF_API_TOKEN safe (workflow_run uses code from main, not the fork) while allowing fork PRs to be fully validated.

- Fixes #301 
