### PR TITLE
Add GitHub repository provisioning for quarkus-http-idempotency

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,6 +60,7 @@ terraform-scripts/quarkus-hibernate-types.tf                    @quarkiverse/qua
 terraform-scripts/quarkus-hivemq-client.tf                      @quarkiverse/quarkiverse-hivemq-client
 terraform-scripts/quarkus-homeassistant.tf                      @quarkiverse/quarkiverse-homeassistant
 terraform-scripts/quarkus-http-problem.tf                       @quarkiverse/quarkiverse-http-problem
+terraform-scripts/quarkus-http-idempotency.tf                   @quarkiverse/quarkiverse-http-idempotency
 terraform-scripts/quarkus-infinispan-embedded.tf                @quarkiverse/quarkiverse-infinispan-embedded
 terraform-scripts/quarkus-itext.tf                              @quarkiverse/quarkiverse-itext
 terraform-scripts/quarkus-jackson-jq.tf                         @quarkiverse/quarkiverse-jackson-jq

--- a/terraform-scripts/quarkus-http-idempotency.tf
+++ b/terraform-scripts/quarkus-http-idempotency.tf
@@ -1,0 +1,70 @@
+# Create repository
+resource "github_repository" "quarkus_http_idempotency" {
+  name                   = "quarkus-http-idempotency"
+  description            = "Make POST and PATCH idempotent"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-http-idempotency/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  topics                 = ["quarkus-extension"]
+}
+
+# Enable vulnerability alerts
+resource "github_repository_vulnerability_alerts" "quarkus_http_idempotency" {
+  repository = github_repository.quarkus_http_idempotency.name
+  enabled    = true
+}
+
+# Create team
+resource "github_team" "quarkus_http_idempotency" {
+  name           = "quarkiverse-http-idempotency"
+  description    = "http-idempotency team"
+  privacy        = "closed"
+  parent_team_id = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_http_idempotency" {
+  team_id    = github_team.quarkus_http_idempotency.id
+  repository = github_repository.quarkus_http_idempotency.name
+  permission = "push"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_http_idempotency" {
+  for_each = { for tm in ["akil-rails", "lu1tr0n"] : tm => tm }
+  team_id  = github_team.quarkus_http_idempotency.id
+  username = each.value
+  role     = "maintainer"
+}
+
+# Protect main branch using a ruleset
+resource "github_repository_ruleset" "quarkus_http_idempotency" {
+  name        = "main"
+  repository  = github_repository.quarkus_http_idempotency.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~DEFAULT_BRANCH"]
+      exclude = []
+    }
+  }
+
+  bypass_actors {
+    actor_id    = data.github_app.quarkiverse_ci.id
+    actor_type  = "Integration"
+    bypass_mode = "always"
+  }
+
+  rules {
+    # Prevent force push
+    non_fast_forward = true
+    # Require pull request reviews before merging
+    pull_request {
+
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Provision new repository `quarkus-http-idempotency` for the [Idempotency-Key HTTP extension](https://github.com/quarkusio/quarkus/issues/49663)
- Team members: `akil-rails`, `lu1tr0n`
- Added CODEOWNERS entry

## Test plan
- [ ] Verify `terraform plan` passes in CI