### PR TITLE
Enable Renovate for Quarkus HTTP Idempotency

### DIFF
--- a/terraform-scripts/quarkus-http-idempotency.tf
+++ b/terraform-scripts/quarkus-http-idempotency.tf
@@ -68,3 +68,11 @@ resource "github_repository_ruleset" "quarkus_http_idempotency" {
     }
   }
 }
+
+# Enable apps in repository
+resource "github_app_installation_repository" "quarkus_http_idempotency" {
+  for_each = { for app in [local.applications.renovate] : app => app }
+  # The installation id of the app (in the organization).
+  installation_id = each.value
+  repository      = github_repository.quarkus_http_idempotency.name
+}


### PR DESCRIPTION
Hi 👋

Following the recommendation in [Quarkiverse Hub Discussion #412](https://github.com/orgs/quarkiverse/discussions/412), this enables the Renovate app for `quarkus-http-idempotency`, mirroring #471.

Once this is merged I will merge the onboarding PR in the extension repository and remove its `.github/dependabot.yml` so a single dependency manager is in place.

Thanks!