### PR TITLE
Add GitHub repo provisioning for quarkus-jdbc-generic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,7 @@ terraform-scripts/quarkus-jasperreports.tf                      @quarkiverse/qua
 terraform-scripts/quarkus-jberet.tf                             @quarkiverse/quarkiverse-jberet
 terraform-scripts/quarkus-jdbc-clickhouse.tf                    @quarkiverse/quarkiverse-jdbc-clickhouse
 terraform-scripts/quarkus-jdbc-edb.tf                           @quarkiverse/quarkiverse-jdbc-edb
+terraform-scripts/quarkus-jdbc-generic.tf                       @quarkiverse/quarkiverse-jdbc-generic
 terraform-scripts/quarkus-jdbc-singlestore.tf                   @quarkiverse/quarkiverse-jdbc-singlestore
 terraform-scripts/quarkus-jdbc-sqlite.tf                        @quarkiverse/quarkiverse-jdbc-sqlite
 terraform-scripts/quarkus-jdbc-sqlite4j.tf                      @quarkiverse/quarkiverse-jdbc-sqlite4j

--- a/terraform-scripts/quarkus-jdbc-generic.tf
+++ b/terraform-scripts/quarkus-jdbc-generic.tf
@@ -1,0 +1,40 @@
+# Create repository
+resource "github_repository" "quarkus_jdbc_generic" {
+  name                   = "quarkus-jdbc-generic"
+  description            = "Connect a Quarkus Agroal datasource to any database via a JDBC driver resolved at runtime"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-jdbc-generic/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  topics                 = ["quarkus-extension"]
+}
+
+# Enable vulnerability alerts
+resource "github_repository_vulnerability_alerts" "quarkus_jdbc_generic" {
+  repository = github_repository.quarkus_jdbc_generic.name
+  enabled    = true
+}
+
+# Create team
+resource "github_team" "quarkus_jdbc_generic" {
+  name           = "quarkiverse-jdbc-generic"
+  description    = "jdbc-generic team"
+  privacy        = "closed"
+  parent_team_id = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_jdbc_generic" {
+  team_id    = github_team.quarkus_jdbc_generic.id
+  repository = github_repository.quarkus_jdbc_generic.name
+  permission = "push"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_jdbc_generic" {
+  for_each = { for tm in ["rmannibucau"] : tm => tm }
+  team_id  = github_team.quarkus_jdbc_generic.id
+  username = each.value
+  role     = "maintainer"
+}


### PR DESCRIPTION
## Summary
- Provisions the `quarkus-jdbc-generic` Quarkiverse repository for @rmannibucau
- Extension connects a Quarkus Agroal datasource to any database via a JDBC driver resolved at runtime
- Adds CODEOWNERS entry for the terraform configuration

Resolves quarkusio/quarkus#55677 (comment: https://github.com/quarkusio/quarkus/pull/55677#issuecomment-5128754344)