### PR TITLE
Add GitHub repo provisioning for quarkus-jdbc-db2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,6 +68,7 @@ terraform-scripts/quarkus-jackson-jq.tf                         @quarkiverse/qua
 terraform-scripts/quarkus-jasperreports.tf                      @quarkiverse/quarkiverse-jasperreports
 terraform-scripts/quarkus-jberet.tf                             @quarkiverse/quarkiverse-jberet
 terraform-scripts/quarkus-jdbc-clickhouse.tf                    @quarkiverse/quarkiverse-jdbc-clickhouse
+terraform-scripts/quarkus-jdbc-db2.tf                           @quarkiverse/quarkiverse-jdbc-db2
 terraform-scripts/quarkus-jdbc-edb.tf                           @quarkiverse/quarkiverse-jdbc-edb
 terraform-scripts/quarkus-jdbc-generic.tf                       @quarkiverse/quarkiverse-jdbc-generic
 terraform-scripts/quarkus-jdbc-singlestore.tf                   @quarkiverse/quarkiverse-jdbc-singlestore

--- a/terraform-scripts/quarkus-jdbc-db2.tf
+++ b/terraform-scripts/quarkus-jdbc-db2.tf
@@ -1,0 +1,40 @@
+# Create repository
+resource "github_repository" "quarkus_jdbc_db2" {
+  name                   = "quarkus-jdbc-db2"
+  description            = "Quarkus DB2 JDBC Driver Extension"
+  homepage_url           = "https://docs.quarkiverse.io/quarkus-jdbc-db2/dev"
+  allow_update_branch    = true
+  archive_on_destroy     = true
+  delete_branch_on_merge = true
+  has_issues             = true
+  topics                 = ["quarkus-extension"]
+}
+
+# Enable vulnerability alerts
+resource "github_repository_vulnerability_alerts" "quarkus_jdbc_db2" {
+  repository = github_repository.quarkus_jdbc_db2.name
+  enabled    = true
+}
+
+# Create team
+resource "github_team" "quarkus_jdbc_db2" {
+  name           = "quarkiverse-jdbc-db2"
+  description    = "jdbc-db2 team"
+  privacy        = "closed"
+  parent_team_id = data.github_team.quarkiverse_members.id
+}
+
+# Add team to repository
+resource "github_team_repository" "quarkus_jdbc_db2" {
+  team_id    = github_team.quarkus_jdbc_db2.id
+  repository = github_repository.quarkus_jdbc_db2.name
+  permission = "push"
+}
+
+# Add users to the team
+resource "github_team_membership" "quarkus_jdbc_db2" {
+  for_each = { for tm in ["Sanne"] : tm => tm }
+  team_id  = github_team.quarkus_jdbc_db2.id
+  username = each.value
+  role     = "maintainer"
+}


### PR DESCRIPTION
## Summary
- Provisions the `quarkus-jdbc-db2` Quarkiverse repository for extracting the DB2 JDBC driver extension from Quarkus core
- Adds @Sanne as maintainer
- Adds CODEOWNERS entry for the terraform configuration