### PR TITLE
Enable Renovate for Quarkus Multitenancy

### DIFF
--- a/terraform-scripts/quarkus-multitenancy.tf
+++ b/terraform-scripts/quarkus-multitenancy.tf
@@ -68,3 +68,11 @@ resource "github_repository_ruleset" "quarkus_multitenancy" {
     }
   }
 }
+
+# Enable apps in repository
+resource "github_app_installation_repository" "quarkus_multitenancy" {
+  for_each = { for app in [local.applications.renovate] : app => app }
+  # The installation id of the app (in the organization).
+  installation_id = each.value
+  repository      = github_repository.quarkus_multitenancy.name
+}


### PR DESCRIPTION
Hi team,

Enables the Renovate GitHub app for `quarkus-multitenancy`, adding the `github_app_installation_repository` block to its Terraform so the repo can migrate from Dependabot to the shared Quarkiverse Renovate config (Quarkiverse #412).

The maintainer signed off in quarkiverse/quarkus-multitenancy#52, agreeing to follow the shared Quarkus LTS policy without a local override. Same pattern as the earlier http-idempotency enablement (#473).

Once this merges, the follow-up is the usual sequence on the repo: review the Renovate onboarding PR, confirm it runs, then drop `.github/dependabot.yml`.

Thanks!