### PR TITLE
Relax Terraform version constraint to allow 1.16.x

### DIFF
--- a/terraform-scripts/main.tf
+++ b/terraform-scripts/main.tf
@@ -14,7 +14,7 @@ terraform {
     }
   }
 
-  required_version = "~> 1.15.0"
+  required_version = "~> 1.15"
 }
 
 provider "github" {}


### PR DESCRIPTION
CI `terraform init` currently fails on all PRs with:

```
Error: Unsupported Terraform Core version
  on main.tf line 17: required_version = "~> 1.15.0"
This configuration does not support Terraform version 1.16.0.
```

The runners now provide Terraform **1.16.0**, but `~> 1.15.0` resolves to `>= 1.15.0, < 1.16.0`. This widens it to `~> 1.15` (`>= 1.15.0, < 2.0.0`) so init succeeds.

Example failing run: https://github.com/quarkiverse/quarkiverse-devops/actions/runs/33068195764/job/98503458442